### PR TITLE
fixed apiUrl construction, separated interfaces,

### DIFF
--- a/src/app/components/modal/modal.component.ts
+++ b/src/app/components/modal/modal.component.ts
@@ -1,14 +1,6 @@
 import { Component, Inject } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
-
-interface ModalJobPost {
-  title: string;
-  openAt: string;
-  closeAt: string;
-  interviewTypes: number;
-  description: string;
-  notes: string;
-}
+import { ModalJobPost } from 'src/app/shared/models/models';
 
 @Component({
   selector: 'app-modal',

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -5,7 +5,7 @@
     <div class="refresh-search-wrapper">
       <button
         class="refresh"
-        (click)="fetchAndDisplayData()"
+        (click)="fetchAndDisplayData('/JobPost')"
         mat-stroked-button
       >
         Refresh

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -5,13 +5,15 @@ import {
   OnDestroy,
   ViewChild,
 } from '@angular/core';
-import { DataService, JobPost } from '../../services/data.service';
+import { JobPost } from 'src/app/shared/models/models';
+import { DataService } from '../../services/data.service';
 import { catchError, throwError, Subscription } from 'rxjs';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatSort } from '@angular/material/sort';
 import { MatPaginator } from '@angular/material/paginator';
 import { ModalComponent } from '../../components/modal/modal.component';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { environment } from 'src/environment/environment';
 
 @Component({
   selector: 'app-home',
@@ -41,10 +43,11 @@ export class HomeComponent implements OnInit, OnDestroy, AfterViewInit {
     };
   }
 
-  fetchAndDisplayData(): void {
+  fetchAndDisplayData(endpointPath: string = '/JobPost'): void {
     this.spinner = true;
+    const fullApiUrl = `${environment.baseUrl}${endpointPath}`;
     this.subscription = this.dataService
-      .getData()
+      .getData(fullApiUrl)
       .pipe(
         catchError((err) => {
           this.spinner = false;

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -2,27 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environment/environment';
-
-export interface JobPost {
-  id: string;
-  title: string;
-  description: string;
-  notes: string;
-  openAt: Date;
-  closeAt: Date;
-  defaultAssignmentId: string;
-  createdAt: Date;
-  updatedAt: Date;
-  isDeleted: boolean;
-  interviewTypes: InterviewType[];
-}
-
-interface InterviewType {
-  id: string;
-  title: string;
-  description: string;
-  order: number;
-}
+import { JobPost } from '../shared/models/models';
 
 @Injectable({
   providedIn: 'root',
@@ -30,13 +10,11 @@ interface InterviewType {
 export class DataService {
   constructor(private http: HttpClient) {}
 
-  private apiUrl = environment.apiUrl;
-
   private bearerToken = environment.bearerToken;
 
   headers = new HttpHeaders().set('Authorization', this.bearerToken);
 
-  getData(): Observable<JobPost[]> {
-    return this.http.get<JobPost[]>(this.apiUrl, { headers: this.headers });
+  getData(fullApiUrl: string): Observable<JobPost[]> {
+    return this.http.get<JobPost[]>(fullApiUrl, { headers: this.headers });
   }
 }

--- a/src/app/shared/models/models.ts
+++ b/src/app/shared/models/models.ts
@@ -1,0 +1,29 @@
+export interface JobPost {
+  id: string;
+  title: string;
+  description: string;
+  notes: string;
+  openAt: Date;
+  closeAt: Date;
+  defaultAssignmentId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  isDeleted: boolean;
+  interviewTypes: InterviewType[];
+}
+
+interface InterviewType {
+  id: string;
+  title: string;
+  description: string;
+  order: number;
+}
+
+export interface ModalJobPost {
+    title: string;
+    openAt: string;
+    closeAt: string;
+    interviewTypes: number;
+    description: string;
+    notes: string;
+  }

--- a/src/environment/environment.example.ts
+++ b/src/environment/environment.example.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  bearerToken: 'xxxx',
+  bearerToken: ' Bearer xxxx',
+  baseUrl: 'https://stage.api.recruitment.indigo.si',
 };


### PR DESCRIPTION
PR #17:

- implemented fullApiUrl construction from baseUrl (in environment.ts) and endpointPath. Full url gets constructed within fetchAndDisplay method (in home.component.ts) with '/JobPost' as the default value. 

- data.service.ts & modal.component.ts: moved interfaces into a separate models.ts file within shared/models folder

- added missing data to environment.example.ts file